### PR TITLE
Fixed unicode and encode Error for artboard(#54)

### DIFF
--- a/Git.sketchplugin/getArtboardNames.py
+++ b/Git.sketchplugin/getArtboardNames.py
@@ -8,6 +8,10 @@ ignore = map(re.compile, filter(None, sys.argv[1].split(",")))
 
 for page in obj["pages"]:
     for artboard in page["artboards"]:
-        name = page["name"] + "/" + artboard["name"]
+        # For Unicode error
+        pageName = page["name"].encode("utf-8")
+        artboardName = artboard["name"].encode("utf-8")
+
+        name = pageName + "/" + artboardName
         if len(ignore) == 0 or all(regex.match(name) == None for regex in ignore):
-            print artboard["name"]
+            print(artboardName)


### PR DESCRIPTION
It is for the issue "Failed commit – Can't encode characte(#54)" 
## Why this modify is needed?

In order to respond to the Japanese and special character for artboards name.

Hi! Thank you for making a good plugin! I use it.
But when I commit, UnicodeEncodeError happen.
Because I used Japanese that is Non-ASCII characters for artboards name.
