### PR TITLE
adds the context parameter when calling executeSafely

### DIFF
--- a/src/commands/Commit.js
+++ b/src/commands/Commit.js
@@ -5,7 +5,7 @@ import { getUserPreferences } from '../preferences'
 
 export default function (context) {
   if (!checkForFile(context)) { return }
-  executeSafely(function () {
+  executeSafely(context, function () {
     sendEvent(context, 'Commit', 'Start commiting')
     var currentBranch = getCurrentBranch(context)
     var commitMsg = createInputWithCheckbox(context, 'Commit to "' + currentBranch + '"', 'Generate files for pretty diffs', getUserPreferences().diffByDefault, 'Commit')

--- a/src/commands/Export.js
+++ b/src/commands/Export.js
@@ -4,7 +4,7 @@ import { checkForFile, executeSafely, exportArtboards } from '../common'
 
 export default function (context) {
   if (!checkForFile(context)) { return }
-  executeSafely(function () {
+  executeSafely(context, function () {
     sendEvent(context, 'Manual Export', 'Do export')
     exportArtboards(context)
     context.document.showMessage('Artboards exported')

--- a/src/commands/Init.js
+++ b/src/commands/Init.js
@@ -4,7 +4,7 @@ import { checkForFile, getCurrentFileName, executeSafely, exec, createInput, cre
 
 export default function (context) {
   if (!checkForFile(context)) { return }
-  executeSafely(function () {
+  executeSafely(context, function () {
     var currentFileName = getCurrentFileName(context)
     if (currentFileName) {
       sendEvent(context, 'Init', 'Start init')

--- a/src/commands/Preferences.js
+++ b/src/commands/Preferences.js
@@ -4,7 +4,7 @@ import { setIconForAlert, executeSafely } from '../common'
 import { getUserPreferences, setUserPreferences } from '../preferences'
 
 export default function (context) {
-  executeSafely(function () {
+  executeSafely(context, function () {
     sendEvent(context, 'Preferences', 'Open preferences')
     const preferences = getUserPreferences()
     var accessory = NSView.alloc().initWithFrame(NSMakeRect(0, 0, 300, 275))

--- a/src/commands/Pull.js
+++ b/src/commands/Pull.js
@@ -4,7 +4,7 @@ import { checkForFile, executeSafely, exec } from '../common'
 
 export default function (context) {
   if (!checkForFile(context)) { return }
-  executeSafely(function () {
+  executeSafely(context, function () {
     sendEvent(context, 'Pull', 'Pull remote')
     exec(context, 'git pull -q')
     context.document.showMessage('Changes pulled')

--- a/src/commands/Push.js
+++ b/src/commands/Push.js
@@ -4,7 +4,7 @@ import { checkForFile, executeSafely, exec } from '../common'
 
 export default function (context) {
   if (!checkForFile(context)) { return }
-  executeSafely(function () {
+  executeSafely(context, function () {
     sendEvent(context, 'Push', 'Push to remote')
     exec(context, 'git -c push.default=current push -q')
     context.document.showMessage('Changes pushed')


### PR DESCRIPTION
This initial argument to `executeSafely` seems to be missing from some calls. Could this be related to #51 ?

I noticed that in > 0.7.0 Sketch would either crash or not do anything when I clicked some of the operations (I think "Branch" worked but "Commit" would silently fail).

At first I thought it was me because I was editing code in this plugin but after running `/Applications/Sketch.app/Contents/MacOS/Sketch` from a terminal and seeing an Undefined error when trying to evaluate `context.plugin.name()` I found this to be the culprit.

Also, I _think_ 0.7.0 crashes when Sketch starts up because it tries to fetch a non-existent `https://raw.githubusercontent.com/mathieudutour/git-sketch-plugin/master/Git.sketchplugin/Contents/Sketch/manifest.json` when checking for updates

refs #81