### PR TITLE
Added support for multiple file formats for pretty diffs

### DIFF
--- a/Git.sketchplugin/exportArtboard.sh
+++ b/Git.sketchplugin/exportArtboard.sh
@@ -5,8 +5,9 @@ EXPORT_FOLDER="$2"
 FILE_FOLDER="$3"
 BUNDLE_PATH="$4"
 FILENAME="$5"
-SCALE="$6"
-INCLUDE_OVERVIEW="$7"
+FORMAT="$6"
+SCALE="$7"
+INCLUDE_OVERVIEW="$8"
 
 
 cd "$DIR_PATH"
@@ -25,7 +26,7 @@ ARTBOARDS=$($BUNDLE_PATH/Contents/Resources/sketchtool/bin/sketchtool list artbo
 
 # generate new artboards
 mkdir -p "$FILE_FOLDER"
-$BUNDLE_PATH/Contents/Resources/sketchtool/bin/sketchtool export artboards "$FILENAME" --scales="$SCALE" --output="$FILE_FOLDER" --overwriting=YES --items="$ARTBOARDS" --include-symbols=YES
+$BUNDLE_PATH/Contents/Resources/sketchtool/bin/sketchtool export artboards "$FILENAME" --formats="$FORMAT" --scales="$SCALE" --output="$FILE_FOLDER" --overwriting=YES --items="$ARTBOARDS" --include-symbols=YES
 
 # Construct a ${FILENAME}-boards.md file which shows all the artboards in the sketch directory
 if [[ ${INCLUDE_OVERVIEW} == "true" ]]

--- a/Resources/preferences.js
+++ b/Resources/preferences.js
@@ -41,6 +41,16 @@ class Preferences extends Component {
           <input type="number" value={preferences.exportScale} id="scale" onInput={this.linkState('preferences.exportScale')} />
         </div>
         <div className="form">
+          <label htmlFor="format">Format of the exported artboards</label>
+          <select id="form" value={preferences.exportFormat} onChange={this.linkState('preferences.exportFormat')}>
+            <option value="png">PNG</option>
+            <option value="jpg">JPG</option>
+            <option value="pdf">PDF</option>
+            <option value="eps">EPS</option>
+            <option value="svg">SVG</option>
+          </select>
+        </div>
+        <div className="form">
           <input type="checkbox" checked={preferences.diffByDefault} id="diffByDefault" onChange={this.linkState('preferences.diffByDefault')} />
           <label htmlFor="diffByDefault"> Generate pretty diff by default</label>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-sketch-plugin",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Plugin to handle versioning in git",
   "main": "Git.sketchplugin",
   "manifest": "src/manifest.json",

--- a/src/common.js
+++ b/src/common.js
@@ -169,11 +169,11 @@ export function exportArtboards (context) {
   const currentFileName = getCurrentFileName(context)
   const path = getCurrentDirectory(context)
   const currentFileNameWithoutExtension = currentFileName.replace(/\.sketch$/, '')
-  const {exportFolder, exportScale, includeOverviewFile} = getUserPreferences()
+  const {exportFolder, exportFormat, exportScale, includeOverviewFile} = getUserPreferences()
   const pluginPath = context.scriptPath.replace(/Contents\/Sketch\/(\w*)\.cocoascript$/, '').replace(/ /g, '\\ ')
   const fileFolder = exportFolder + '/' + currentFileNameWithoutExtension
 
-  const command = `${pluginPath}/exportArtboard.sh "${path}" "${exportFolder}" "${fileFolder}" "${NSBundle.mainBundle().bundlePath()}" "${currentFileName}" "${exportScale}" "${includeOverviewFile}"`
+  const command = `${pluginPath}/exportArtboard.sh "${path}" "${exportFolder}" "${fileFolder}" "${NSBundle.mainBundle().bundlePath()}" "${currentFileName}" "${exportFormat}" "${exportScale}" "${includeOverviewFile}"`
   return exec(context, command)
 }
 

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -5,6 +5,7 @@ const keyPref = 'gitSketch'
 export function getUserPreferences () {
   return prefsManager.getUserPreferences(keyPref, {
     exportFolder: '.exportedArtboards',
+    exportFormat: 'png',
     exportScale: '1.0',
     terminal: 'Terminal',
     diffByDefault: true,


### PR DESCRIPTION
I added support for choosing the file format the pretty diff images are generated in.
All sketchtool supported file formats are listed in the preference panel, so users get to choose whether to export the pretty diff images as png (default), jpg, pdf, eps or svg.