### PR TITLE
only execute the  `exportArtboards` function in git repository

### DIFF
--- a/src/commands/Export.js
+++ b/src/commands/Export.js
@@ -1,10 +1,10 @@
 // Export artboards for pretty diffs
 import { sendEvent } from '../analytics'
-import { checkForFile, executeSafely, exportArtboards } from '../common'
+import { checkForFile, checkForGitRepository, executeSafely, exportArtboards } from '../common'
 import { getUserPreferences } from '../preferences'
 
 export default function (context) {
-  if (!checkForFile(context)) { return }
+  if (!checkForFile(context) && !checkForGitRepository(context)) { return }
   executeSafely(context, function () {
     sendEvent(context, 'Manual Export', 'Do export')
     exportArtboards(context, getUserPreferences(context))

--- a/src/common.js
+++ b/src/common.js
@@ -190,11 +190,20 @@ export function checkForFile (context) {
   try {
     getCurrentFileName(context)
     getCurrentDirectory(context)
-    getGitDirectory(context)
     return true
   } catch (e) {
     sendError(context, 'Missing file')
     createFailAlert(context, 'Missing file', 'You need to open a sketch file before doing that')
+    return false
+  }
+}
+export function checkForGitRepository (context) {
+  try {
+    getGitDirectory(context)
+    return true
+  } catch (e) {
+    sendError(context, 'Not a git repository')
+    createFailAlert(context, 'Not a git repository', 'You need to init git repository first')
     return false
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -190,6 +190,7 @@ export function checkForFile (context) {
   try {
     getCurrentFileName(context)
     getCurrentDirectory(context)
+    getGitDirectory(context)
     return true
   } catch (e) {
     sendError(context, 'Missing file')


### PR DESCRIPTION
when `exportArtboards`, the faild alert will be show, 
but actully, the export action has done!

![image](https://cloud.githubusercontent.com/assets/5205912/25877899/422cb5c8-3559-11e7-8847-5b1af99cf862.png)
