### PR TITLE
URL-encode artboard image paths in the overview markdown.

### DIFF
--- a/Git.sketchplugin/exportArtboard.sh
+++ b/Git.sketchplugin/exportArtboard.sh
@@ -70,10 +70,11 @@ do
   if [[ ${INCLUDE_OVERVIEW} == "true" ]]
   then
     artboardName="${artboard%.*}" # Exclude the file extension
+    artboardPathUrlEncoded=$(python -c "import urllib;print urllib.quote(raw_input())" <<< "$artboardPath")
     echo "" >> "${readmeFile}"
     echo "## ${artboardName}" >> "${readmeFile}"
     echo "" >> "${readmeFile}"
-    echo "![${artboardName}](./${artboardPath})" >> "${readmeFile}"
+    echo "![${artboardName}](./${artboardPathUrlEncoded})" >> "${readmeFile}"
     echo "" >> "${readmeFile}"
   fi
 done


### PR DESCRIPTION
Fixes broken image links in the overview markdown when pages/artboards have non-URL-safe characters in their names.

Sample diff from a generated `boards.md` file before/after this PR:

```diff
--- a/my_sketch-boards.md
+++ b/my_sketch-boards.md
@@ -4,12 +4,12 @@ This is an autogenerated file showing all the artboards. Do not edit it directly

 ## My artboard

-![My artboard](./.exportedArtboards/my_sketch/My artboard.png)
+![My artboard](./.exportedArtboards/my_sketch/My%20artboard.png)
```