### PR TITLE
Fix NSArray Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.11.3] - 2017-10-16
+
+* Fix NSArray error which blocked committing and generating files for diffs. 
+
+
 ## [0.11.2] - 2017-05-25
 
 * URL-encode artboard image paths in the overview markdown (Thanks @mattjbray)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-sketch-plugin",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Plugin to handle versioning in git",
   "main": "Git.sketchplugin",
   "manifest": "src/manifest.json",

--- a/src/common.js
+++ b/src/common.js
@@ -24,7 +24,7 @@ export function exec (context, command) {
   command = `cd "${path}" && ${command}`
 
   task.setLaunchPath_('/bin/bash')
-  task.setArguments_(NSArray.arrayWithObjects_('-c', '-l', command, null))
+  task.setArguments_(NSArray.arrayWithArray_(['-c', '-l', command]))
   task.standardOutput = pipe
   task.standardError = errPipe
   task.launch()


### PR DESCRIPTION
Fixes two issues reported: #154 and #155 

On Mac OS 10.13 and Sketch version 47 committing and generating files for pretty diffs resulted in NSArray errors. I found a similar issue https://github.com/tudou527/marketch/pull/158 in another sketch plugin and was able to debug this issue. 

I tested this locally and was able to both commit and generate files via "Generate files for pretty diffs"

I wasn't sure if I should bump the version but I did anyway - happy to make any changes. 